### PR TITLE
Fix asset copy in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,11 @@ fi
 # Prepare build output directory
 echo "📁 Preparing build output..."
 rm -rf build/
-mkdir -p build/res
+mkdir -p build
 
 # Copy binary and required assets
 cp "$BIN_PATH" build/partydeck-rs
+cp -r res build/
 cp res/PartyDeckKWinLaunch.sh build/
-cp res/splitscreen_kwin.js build/res
 
 echo "✅ Build complete – files are in ./build"


### PR DESCRIPTION
## Summary
- ensure the entire `res` directory is copied during build

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f13d3ca7c832ab4448ff19540b7f7