### PR TITLE
Add about page and update images

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,4 +1,4 @@
-use crate::handler::{install_handler_from_file, scan_handlers, Handler};
+use crate::handler::{Handler, install_handler_from_file, scan_handlers};
 use crate::paths::*;
 
 use eframe::egui::{self, ImageSource};
@@ -42,7 +42,7 @@ impl Game {
                 if path.exists() {
                     format!("file://{}", path.display()).into()
                 } else {
-                    egui::include_image!("../res/icon.png")
+                    egui::include_image!("../.github/assets/sdh.svg")
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod handler;
 mod input;
 mod launch;
 mod paths;
-mod util;
 mod task;
+mod util;
 
 use crate::app::*;
 use crate::paths::*;
@@ -67,8 +67,10 @@ fn main() -> eframe::Result {
             .with_min_inner_size([640.0, 360.0])
             .with_fullscreen(fullscreen)
             .with_icon(
-                eframe::icon_data::from_png_bytes(&include_bytes!("../res/icon.png")[..])
-                    .expect("Failed to load icon"),
+                eframe::icon_data::from_png_bytes(
+                    &include_bytes!("../.github/assets/icon.png")[..],
+                )
+                .expect("Failed to load icon"),
             ),
         ..Default::default()
     };


### PR DESCRIPTION
## Summary
- display steam header images when possible
- add new About page and remove version from top panel
- replace default icons with sdh logo

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_684fdc8a1da4832aa0e637b1185a0fb7