### PR TITLE
Improve UI spacing and fonts

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -8,7 +8,7 @@ use crate::task::Task;
 use crate::util::*;
 
 use dialog::DialogBox;
-use eframe::egui::{self, Color32, Key, RichText, Ui};
+use eframe::egui::{self, Color32, Key, RichText, TextStyle, Ui};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 use regex::Regex;
 use std::path::PathBuf;
@@ -82,14 +82,28 @@ impl eframe::App for PartyApp {
         egui::SidePanel::left("left_panel")
             .resizable(false)
             .exact_width(side_w)
-            .frame(egui::Frame::default().fill(Color32::from_gray(40)))
+            .frame(
+                egui::Frame::default()
+                    .fill(Color32::from_gray(40))
+                    .stroke(egui::Stroke::NONE)
+                    .inner_margin(egui::Margin {
+                        left: 15,
+                        top: 0,
+                        right: 0,
+                        bottom: 0,
+                    }),
+            )
             .show(ctx, |ui| {
                 self.display_left_panel(ui);
             });
 
         egui::TopBottomPanel::top("nav_bar")
             .exact_height(60.0)
-            .frame(egui::Frame::default().fill(Color32::from_gray(40)))
+            .frame(
+                egui::Frame::default()
+                    .fill(Color32::from_gray(40))
+                    .stroke(egui::Stroke::NONE),
+            )
             .show(ctx, |ui| {
                 self.display_nav_bar(ui, ctx);
             });
@@ -142,8 +156,13 @@ impl PartyApp {
                         .max_height(60.0),
                 );
             });
-            ui.separator();
-            ui.label("Gamepads:");
+            ui.add_space(6.0);
+            egui::Frame::none()
+                .fill(Color32::from_gray(50))
+                .inner_margin(egui::Margin::same(2))
+                .show(ui, |ui| {
+                    ui.label(RichText::new("GAMEPADS:").text_style(TextStyle::Name("H3".into())));
+                });
             if self.pads.is_empty() {
                 ui.label("No Gamepads detected");
             } else {
@@ -156,7 +175,12 @@ impl PartyApp {
                     });
                 }
             }
-            if ui.button("Rescan").clicked() {
+            if ui
+                .add(egui::Button::new(
+                    RichText::new("Rescan").text_style(TextStyle::Body),
+                ))
+                .clicked()
+            {
                 self.players.clear();
                 self.pads.clear();
                 self.pads = scan_evdev_gamepads();
@@ -177,8 +201,10 @@ impl PartyApp {
             ];
             for (page, label) in pages {
                 let resp = ui.add(
-                    egui::Label::new(RichText::new(label).text_style(egui::TextStyle::Button))
-                        .sense(egui::Sense::click()),
+                    egui::Label::new(
+                        RichText::new(label).text_style(egui::TextStyle::Name("Nav".into())),
+                    )
+                    .sense(egui::Sense::click()),
                 );
                 if self.cur_page == page {
                     let stroke = egui::Stroke::new(1.0, Color32::from_rgb(0, 177, 227));
@@ -199,12 +225,20 @@ impl PartyApp {
             }
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui.button("Quit").clicked() {
+                let quit = ui.add(
+                    egui::Label::new(
+                        RichText::new("QUIT").text_style(egui::TextStyle::Name("Nav".into())),
+                    )
+                    .sense(egui::Sense::click()),
+                );
+                if quit.clicked() {
                     ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                 }
                 let resp = ui.add(
-                    egui::Label::new(RichText::new("ABOUT").text_style(egui::TextStyle::Button))
-                        .sense(egui::Sense::click()),
+                    egui::Label::new(
+                        RichText::new("ABOUT").text_style(egui::TextStyle::Name("Nav".into())),
+                    )
+                    .sense(egui::Sense::click()),
                 );
                 if self.cur_page == MenuPage::About {
                     let stroke = egui::Stroke::new(1.0, Color32::from_rgb(0, 177, 227));

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,12 @@ fn setup_style(ctx: &egui::Context) {
             "../res/DejaVuSans.ttf"
         ))),
     );
+    fonts.font_data.insert(
+        "dejavu-bold".to_owned(),
+        std::sync::Arc::new(FontData::from_static(include_bytes!(
+            "../res/DejaVuSans-Bold.ttf"
+        ))),
+    );
     fonts
         .families
         .entry(FontFamily::Proportional)
@@ -32,6 +38,11 @@ fn setup_style(ctx: &egui::Context) {
         .entry(FontFamily::Monospace)
         .or_default()
         .insert(0, "dejavu".to_owned());
+    fonts
+        .families
+        .entry(FontFamily::Name("bold".into()))
+        .or_default()
+        .insert(0, "dejavu-bold".to_owned());
     ctx.set_fonts(fonts);
 
     let mut style = Style::default();
@@ -41,16 +52,25 @@ fn setup_style(ctx: &egui::Context) {
     style.visuals.selection.bg_fill = Color32::from_rgb(130, 100, 190);
     style.spacing.button_padding = egui::vec2(12.0, 8.0);
     style.spacing.item_spacing = egui::vec2(10.0, 8.0);
-    style.text_styles.insert(
-        TextStyle::Heading,
-        FontId::new(22.0, FontFamily::Proportional),
-    );
-    style
-        .text_styles
-        .insert(TextStyle::Body, FontId::new(13.0, FontFamily::Proportional));
+
     style.text_styles.insert(
         TextStyle::Button,
         FontId::new(14.0, FontFamily::Proportional),
+    );
+    style.text_styles.insert(
+        TextStyle::Heading,
+        FontId::new(20.0, FontFamily::Name("bold".into())),
+    );
+    style
+        .text_styles
+        .insert(TextStyle::Body, FontId::new(14.0, FontFamily::Proportional));
+    style.text_styles.insert(
+        TextStyle::Name("H3".into()),
+        FontId::new(16.0, FontFamily::Name("bold".into())),
+    );
+    style.text_styles.insert(
+        TextStyle::Name("Nav".into()),
+        FontId::new(26.0, FontFamily::Name("bold".into())),
     );
     ctx.set_style(style);
 }


### PR DESCRIPTION
## Summary
- load DejaVu bold font
- set up hierarchy of text styles
- pad left sidebar and darken status heading
- unify navigation styling with custom text style

## Testing
- `cargo build`
