### PR TITLE
Rename PartyDeck to SteamDeckHengst

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-handler-request.md
+++ b/.github/ISSUE_TEMPLATE/game-handler-request.md
@@ -8,7 +8,7 @@ assignees: blckink
 ---
 
 **Controller support**
-Does the game have native controller support? If not, is there a mod for the game that adds controller support? Specify that here. Do note that PartyDeck is a controller-only app for now, so any game that only supports keyboard and mouse for input will not work.
+Does the game have native controller support? If not, is there a mod for the game that adds controller support? Specify that here. Do note that SteamDeckHengst is a controller-only app for now, so any game that only supports keyboard and mouse for input will not work.
 
 **PCGamingWiki Article**
 Search your game on PCGamingWiki, and put a link to the article here. PCGW articles contain lots of info that help a lot with handler creation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,39 +3388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "partydeck-rs"
-version = "0.3.2"
-dependencies = [
- "chrono",
- "compress-tools",
- "crossbeam-channel",
- "dialog",
- "eframe",
- "egui_commonmark",
- "egui_extras",
- "env_logger",
- "evdev",
- "fastrand",
- "image",
- "num_cpus",
- "once_cell",
- "rand 0.9.1",
- "regex",
- "reqwest",
- "rfd",
- "semver",
- "serde",
- "serde_json",
- "steamlocate",
- "tar",
- "threadpool",
- "walkdir",
- "x11rb",
- "zbus 5.6.0",
- "zip",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4492,6 +4459,39 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "steamdeckhengst"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "compress-tools",
+ "crossbeam-channel",
+ "dialog",
+ "eframe",
+ "egui_commonmark",
+ "egui_extras",
+ "env_logger",
+ "evdev",
+ "fastrand",
+ "image",
+ "num_cpus",
+ "once_cell",
+ "rand 0.9.1",
+ "regex",
+ "reqwest",
+ "rfd",
+ "semver",
+ "serde",
+ "serde_json",
+ "steamlocate",
+ "tar",
+ "threadpool",
+ "walkdir",
+ "x11rb",
+ "zbus 5.6.0",
+ "zip",
+]
 
 [[package]]
 name = "steamlocate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "partydeck-rs"
+name = "steamdeckhengst"
 version = "0.3.2"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@
 
 1. Launch in Desktop Mode:
    ```bash
-   partydeck-rs
+   steamdeckhengst
    ```
 
 2. Gaming Mode?  
-   Add `PartyDeckKWinLaunch.sh` as a non-Steam game and disable Steam Input. That’s it.
+   Add `SteamDeckHengstKWinLaunch.sh` as a non-Steam game and disable Steam Input. That’s it.
 
 ### Desktop Linux
 
@@ -60,7 +60,7 @@
 
 2. Then:
    ```bash
-   partydeck-rs
+   steamdeckhengst
    ```
 
 3. Disable Steam Input layouts for controllers.
@@ -124,7 +124,7 @@ You'll need these for game launching and sandboxing:
 
 ## 🤝 Credits
 
-- 🛠️ [wunnr](https://github.com/wunnr) – partydeck-rs mastermind  
+- 🛠️ [wunnr](https://github.com/wunnr) – partydeck-rs mastermind
 - 🧠 [MrGoldberg](https://github.com/Detanup01/gbe_fork) – Steam API wizardry  
 - 🍷 [GloriousEggroll](https://github.com/Open-Wine-Components/umu-launcher) – Proton magic  
 - 🧩 [Tau5](https://github.com/Tau5/Co-op-on-Linux) & [Syntrait](https://github.com/Syntrait/splinux)  

--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,10 @@ echo "📦 Building in $BUILD_MODE mode..."
 
 if [ "$BUILD_MODE" = "debug" ]; then
     cargo build
-    BIN_PATH="target/debug/partydeck-rs"
+    BIN_PATH="target/debug/steamdeckhengst"
 else
     cargo build --release
-    BIN_PATH="target/release/partydeck-rs"
+    BIN_PATH="target/release/steamdeckhengst"
 fi
 
 # Verify binary exists
@@ -25,8 +25,8 @@ rm -rf build/
 mkdir -p build
 
 # Copy binary and required assets
-cp "$BIN_PATH" build/partydeck-rs
+cp "$BIN_PATH" build/steamdeckhengst
 cp -r res build/
-cp res/PartyDeckKWinLaunch.sh build/
+cp res/SteamDeckHengstKWinLaunch.sh build/
 
 echo "✅ Build complete – files are in ./build"

--- a/res/SteamDeckHengstKWinLaunch.sh
+++ b/res/SteamDeckHengstKWinLaunch.sh
@@ -4,4 +4,4 @@ resolution=$(xrandr | grep '*' | awk '{print $1}')
 width=$(echo $resolution | cut -d 'x' -f 1)
 height=$(echo $resolution | cut -d 'x' -f 2)
 
-kwin_wayland --xwayland --width $width --height $height --exit-with-session "konsole -e ./partydeck-rs --fullscreen"
+kwin_wayland --xwayland --width $width --height $height --exit-with-session "konsole -e ./steamdeckhengst --fullscreen"

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -48,7 +48,7 @@ impl Default for PartyApp {
         Self {
             needs_update: false,
             update_check: Some(Task::spawn(|| {
-                check_for_partydeck_update().unwrap_or(false)
+                check_for_steamdeckhengst_update().unwrap_or(false)
             })),
             options: load_cfg(),
             cur_page: MenuPage::Games,
@@ -389,7 +389,7 @@ impl PartyApp {
             self.infotext = "Forces games to use the version of SDL2 included in the Steam Runtime. Only works on native Linux games, may fix problematic game controller support (incorrect mappings) in some games, may break others. If unsure, leave this unchecked.".to_string();
         }
         if render_scale_slider.hovered() {
-            self.infotext = "PartyDeck divides each instance by a base resolution. 100% render scale = your monitor's native resolution. Lower this value to increase performance, but may cause graphical issues or even break some games. If you're using a small screen like the Steam Deck's handheld screen, increase this to 150% or higher.".to_string();
+            self.infotext = "SteamDeckHengst divides each instance by a base resolution. 100% render scale = your monitor's native resolution. Lower this value to increase performance, but may cause graphical issues or even break some games. If you're using a small screen like the Steam Deck's handheld screen, increase this to 150% or higher.".to_string();
         }
         if gamescope_sdl_backend_check.hovered() {
             self.infotext = "Runs gamescope sessions using the SDL backend. If unsure, leave this checked. If gamescope sessions only show a black screen or give an error (especially on Nvidia + Wayland), try disabling this.".to_string();
@@ -411,7 +411,7 @@ impl PartyApp {
 
         ui.horizontal(|ui| {
         if ui.button("Erase Proton Prefix").clicked() {
-            if yesno("Erase Prefix?", "This will erase the Wine prefix used by PartyDeck. This shouldn't erase profile/game-specific data, but exercise caution. Are you sure?") && PATH_PARTY.join("gamesyms").exists() {
+            if yesno("Erase Prefix?", "This will erase the Wine prefix used by SteamDeckHengst. This shouldn't erase profile/game-specific data, but exercise caution. Are you sure?") && PATH_PARTY.join("gamesyms").exists() {
                 if let Err(err) = std::fs::remove_dir_all(PATH_PARTY.join("pfx")) {
                     msg("Error", &format!("Couldn't erase pfx data: {}", err));
                 }
@@ -452,13 +452,13 @@ impl PartyApp {
         });
 
         ui.horizontal(|ui| {
-            if ui.button("Open PartyDeck Data Folder").clicked() {
+            if ui.button("Open SteamDeckHengst Data Folder").clicked() {
                 if let Err(_) = std::process::Command::new("sh")
                     .arg("-c")
                     .arg(format!("xdg-open {}/", PATH_PARTY.display()))
                     .status()
                 {
-                    msg("Error", "Couldn't open PartyDeck Data Folder!");
+                    msg("Error", "Couldn't open SteamDeckHengst Data Folder!");
                 }
             }
             if ui.button("Edit game paths").clicked() {

--- a/src/game.rs
+++ b/src/game.rs
@@ -84,7 +84,7 @@ pub fn scan_all_games() -> Vec<Game> {
 
 pub fn add_game() -> Result<(), Box<dyn Error>> {
     let file = FileDialog::new()
-        .set_title("Select Linux/Windows Program or PartyDeck Handler (.pdh)")
+        .set_title("Select Linux/Windows Program or SteamDeckHengst Handler (.pdh)")
         .set_directory(&*PATH_HOME)
         .pick_file();
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -95,13 +95,8 @@ pub fn launch_from_handler(
         let path_prof = &format!("{party}/profiles/{}", p.profname.as_str());
         let path_save = &format!("{path_prof}/saves/{}", h.uid.as_str());
 
-        let (gsc_width, gsc_height) = get_instance_resolution(
-            players.len(),
-            i,
-            width,
-            height,
-            cfg.vertical_two_player,
-        );
+        let (gsc_width, gsc_height) =
+            get_instance_resolution(players.len(), i, width, height, cfg.vertical_two_player);
 
         if gsc_height < 600 && res_warn {
             msg(
@@ -251,13 +246,8 @@ pub fn launch_executable(
 
     cmd.push_str(&format!("cd \"{gamedir}\"; "));
     for (i, p) in players.iter().enumerate() {
-        let (gsc_width, gsc_height) = get_instance_resolution(
-            players.len(),
-            i,
-            width,
-            height,
-            cfg.vertical_two_player,
-        );
+        let (gsc_width, gsc_height) =
+            get_instance_resolution(players.len(), i, width, height, cfg.vertical_two_player);
 
         if gsc_height < 600 && res_warn {
             msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> eframe::Result {
     if !PATH_RES.join("umu-run").exists() {
         msg(
             "Downloading Dependencies",
-            "UMU Launcher not found in resources folder. PartyDeck uses UMU to launch Windows games with Proton. Click OK to automatically download from the internet.",
+            "UMU Launcher not found in resources folder. SteamDeckHengst uses UMU to launch Windows games with Proton. Click OK to automatically download from the internet.",
         );
         if let Err(e) = update_umu_launcher() {
             println!("Failed to download UMU Launcher: {}", e);
@@ -103,7 +103,7 @@ fn main() -> eframe::Result {
     if !PATH_RES.join("goldberg_linux").exists() || !PATH_RES.join("goldberg_win").exists() {
         msg(
             "Downloading Dependencies",
-            "Goldberg Steam Emu not found in resources folder. PartyDeck uses Goldberg for LAN play. Click OK to automatically download from the internet.",
+            "Goldberg Steam Emu not found in resources folder. SteamDeckHengst uses Goldberg for LAN play. Click OK to automatically download from the internet.",
         );
         if let Err(e) = update_goldberg_emu() {
             println!("Failed to download Goldberg: {}", e);
@@ -114,7 +114,7 @@ fn main() -> eframe::Result {
         }
     }
 
-    println!("\n[PARTYDECK] started\n");
+    println!("\n[STEAMDECKHENGST] started\n");
 
     let fullscreen = std::env::args().any(|arg| arg == "--fullscreen");
 
@@ -139,7 +139,7 @@ fn main() -> eframe::Result {
         ..Default::default()
     };
     eframe::run_native(
-        "PartyDeck",
+        "SteamDeckHengst",
         options,
         Box::new(|cc| {
             // This gives us image support:

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -11,9 +11,9 @@ pub static PATH_HOME: LazyLock<PathBuf> =
 pub static PATH_LOCAL_SHARE: LazyLock<PathBuf> = LazyLock::new(|| PATH_HOME.join(".local/share"));
 pub static PATH_PARTY: LazyLock<PathBuf> = LazyLock::new(|| {
     if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
-        return PathBuf::from(xdg_data_home).join("partydeck");
+        return PathBuf::from(xdg_data_home).join("steamdeckhengst");
     }
-    PATH_LOCAL_SHARE.join("partydeck")
+    PATH_LOCAL_SHARE.join("steamdeckhengst")
 });
 pub static PATH_STEAM: LazyLock<PathBuf> = LazyLock::new(|| {
     if let Ok(steamdir) = steamlocate::SteamDir::locate() {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,4 @@
-use crossbeam_channel::{unbounded, Receiver};
+use crossbeam_channel::{Receiver, unbounded};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 use threadpool::ThreadPool;

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -1,13 +1,13 @@
 use crate::paths::PATH_PARTY;
+use chrono::Local;
 use std::fs::OpenOptions;
 use std::io::Write;
-use chrono::Local;
 
 pub fn log_info(msg: &str) {
     if let Ok(mut file) = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(PATH_PARTY.join("partydeck.log"))
+        .open(PATH_PARTY.join("steamdeckhengst.log"))
     {
         let _ = writeln!(
             file,
@@ -22,7 +22,7 @@ pub fn log_error(msg: &str) {
     if let Ok(mut file) = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(PATH_PARTY.join("partydeck.log"))
+        .open(PATH_PARTY.join("steamdeckhengst.log"))
     {
         let _ = writeln!(
             file,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,9 +1,9 @@
 // Re-export all utility functions from submodules
 mod filesystem;
+mod logger;
 mod profiles;
 mod sys;
 mod updates;
-mod logger;
 
 // Re-export functions from profiles
 pub use profiles::{create_gamesave, create_profile, remove_guest_profiles, scan_profiles};
@@ -20,4 +20,4 @@ pub use sys::{
 pub use logger::{log_error, log_info};
 
 // Re-export functions from updates
-pub use updates::{check_for_partydeck_update, update_goldberg_emu, update_umu_launcher};
+pub use updates::{check_for_steamdeckhengst_update, update_goldberg_emu, update_umu_launcher};

--- a/src/util/sys.rs
+++ b/src/util/sys.rs
@@ -51,7 +51,7 @@ pub fn get_instance_resolution(
             } else {
                 (basewidth / 2, baseheight)
             }
-        },
+        }
         3 => {
             if i == 0 {
                 (basewidth, baseheight / 2)

--- a/src/util/updates.rs
+++ b/src/util/updates.rs
@@ -2,11 +2,11 @@ use crate::paths::*;
 
 use std::error::Error;
 
-pub fn check_for_partydeck_update() -> Result<bool, Box<dyn Error>> {
+pub fn check_for_steamdeckhengst_update() -> Result<bool, Box<dyn Error>> {
     let client = reqwest::blocking::Client::new();
     let response = client
         .get("https://api.github.com/repos/blckink/steamdeckhengst/releases/latest")
-        .header("User-Agent", "partydeck")
+        .header("User-Agent", "steamdeckhengst")
         .send()?;
     let release: serde_json::Value = response.json()?;
     if let Some(tag_name) = release["tag_name"].as_str() {
@@ -19,7 +19,6 @@ pub fn check_for_partydeck_update() -> Result<bool, Box<dyn Error>> {
     Ok(false)
 }
 
-
 pub fn update_umu_launcher() -> Result<(), Box<dyn Error>> {
     use compress_tools::*;
 
@@ -31,7 +30,7 @@ pub fn update_umu_launcher() -> Result<(), Box<dyn Error>> {
     let client = reqwest::blocking::Client::new();
     let response = client
         .get("https://api.github.com/repos/Open-Wine-Components/umu-launcher/releases/latest")
-        .header("User-Agent", "partydeck")
+        .header("User-Agent", "steamdeckhengst")
         .send()?;
 
     let release: serde_json::Value = response.json()?;
@@ -86,7 +85,7 @@ pub fn update_goldberg_emu() -> Result<(), Box<dyn Error>> {
     let client = reqwest::blocking::Client::new();
     let response = client
         .get("https://api.github.com/repos/Detanup01/gbe_fork/releases/latest")
-        .header("User-Agent", "partydeck")
+        .header("User-Agent", "steamdeckhengst")
         .send()?;
 
     let release: serde_json::Value = response.json()?;


### PR DESCRIPTION
## Summary
- rename scripts and paths from PartyDeck to SteamDeckHengst
- change package name to `steamdeckhengst`
- update docs to reference SteamDeckHengst
- adjust code for new update function and logging
- keep PartyDeck reference when crediting wunnr

## Testing
- No testing due to minor changes