### PR TITLE
Add setting to ignore Steam Input devices

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -7,12 +7,14 @@ use std::io::BufReader;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
+#[serde(default)]
 pub struct PartyConfig {
     pub force_sdl: bool,
     pub render_scale: i32,
     pub gamescope_sdl_backend: bool,
     pub proton_version: String,
     pub vertical_two_player: bool,
+    pub disable_steam_input: bool,
 }
 
 pub fn load_cfg() -> PartyConfig {
@@ -25,13 +27,7 @@ pub fn load_cfg() -> PartyConfig {
     }
 
     // Return default settings if file doesn't exist or has error
-    PartyConfig {
-        force_sdl: false,
-        render_scale: 100,
-        gamescope_sdl_backend: true,
-        proton_version: "".to_string(),
-        vertical_two_player: true,
-    }
+    PartyConfig::default()
 }
 
 pub fn save_cfg(config: &PartyConfig) -> Result<(), Box<dyn Error>> {
@@ -39,4 +35,17 @@ pub fn save_cfg(config: &PartyConfig) -> Result<(), Box<dyn Error>> {
     let file = File::create(path)?;
     serde_json::to_writer_pretty(file, config)?;
     Ok(())
+}
+
+impl Default for PartyConfig {
+    fn default() -> Self {
+        Self {
+            force_sdl: false,
+            render_scale: 100,
+            gamescope_sdl_backend: true,
+            proton_version: String::new(),
+            vertical_two_player: true,
+            disable_steam_input: true,
+        }
+    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -117,9 +117,20 @@ impl Gamepad {
     }
 }
 
-pub fn scan_evdev_gamepads() -> Vec<Gamepad> {
+pub fn scan_evdev_gamepads(filter_steam: bool) -> Vec<Gamepad> {
     let mut pads: Vec<Gamepad> = Vec::new();
     for dev in evdev::enumerate() {
+        if filter_steam {
+            let vendor = dev.1.input_id().vendor();
+            if vendor == 0x28de {
+                continue;
+            }
+            if let Some(name) = dev.1.name() {
+                if name.contains("Steam Virtual Gamepad") {
+                    continue;
+                }
+            }
+        }
         let has_btn_south = dev
             .1
             .supported_keys()


### PR DESCRIPTION
## Summary
- add `disable_steam_input` option to `PartyConfig`
- filter Steam virtual gamepads in `scan_evdev_gamepads`
- show checkbox for this option in Settings menu

## Testing
- `cargo build`
