### PR TITLE
Add optional HID battery feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hidapi"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3414,7 @@ dependencies = [
  "env_logger",
  "evdev",
  "fastrand",
+ "hidapi",
  "image",
  "num_cpus",
  "once_cell",
@@ -5645,6 +5659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ num_cpus = "1.16.0"
 chrono = "0.4"
 egui_commonmark = "0.20"
 regex = "1"
+hidapi = { version = "2.6.3", optional = true, default-features = false, features = ["linux-native"] }
+
+[features]
+default = []
+hid-battery = ["hidapi"]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@
 # Debug mode (optional):
 export BUILD_MODE=debug
 ./build.sh
+
+# Optional HID battery support (requires libudev):
+cargo build --features hid-battery
 ```
 
 Result: Everything ends up in `/build`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -68,17 +68,51 @@ impl Gamepad {
     }
 
     pub fn battery_percent(&self) -> Option<u8> {
+        if let Some(b) = self.battery_percent_sys() {
+            return Some(b);
+        }
+        #[cfg(feature = "hid-battery")]
+        if self.dev.input_id().vendor() == 0x054c {
+            return self.battery_percent_hid();
+        }
+        None
+    }
+
+    fn battery_percent_sys(&self) -> Option<u8> {
         let name = std::path::Path::new(&self.path)
             .file_name()
             .and_then(|p| p.to_str())?;
-        let mut sys_path = std::path::PathBuf::from("/sys/class/power_supply");
-        for entry in std::fs::read_dir(&sys_path).ok()? {
+        let sys_path = std::path::Path::new("/sys/class/power_supply");
+        for entry in std::fs::read_dir(sys_path).ok()? {
             let entry = entry.ok()?;
             if let Ok(content) = std::fs::read_to_string(entry.path().join("uevent")) {
                 if content.contains(name) {
                     if let Ok(cap) = std::fs::read_to_string(entry.path().join("capacity")) {
                         if let Ok(val) = cap.trim().parse::<u8>() {
                             return Some(val);
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(feature = "hid-battery")]
+    fn battery_percent_hid(&self) -> Option<u8> {
+        use hidapi::HidApi;
+        let vid = self.dev.input_id().vendor();
+        let pid = self.dev.input_id().product();
+        let api = HidApi::new().ok()?;
+        for info in api.device_list() {
+            if info.vendor_id() == vid && info.product_id() == pid {
+                if let Ok(device) = info.open_device(&api) {
+                    let mut buf = [0u8; 64];
+                    buf[0] = 0x02;
+                    if device.get_feature_report(&mut buf).is_ok() {
+                        let level = buf[53];
+                        if level <= 10 {
+                            return Some(level * 10);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- make `hidapi` optional behind `hid-battery` feature
- document how to enable HID battery support
- gate DS5 battery function with feature flag

## Testing
- `cargo build --quiet` *(fails: Unable to find libudev)*

------
https://chatgpt.com/codex/tasks/task_e_68507ff577b0832a82ae6d847328a097