### PR TITLE
Add keepAbove to KWin scripts

### DIFF
--- a/res/splitscreen_kwin.js
+++ b/res/splitscreen_kwin.js
@@ -61,6 +61,8 @@ function gamescopeSplitscreen(){
 
     for (var i = 0; i < gamescopeClients.length; i++){
         gamescopeClients[i].noBorder = true;
+        gamescopeClients[i].keepAbove = true;
+        gamescopeClients[i].skipTaskbar = true;
         gamescopeClients[i].frameGeometry = {
             x: Xpos[i],
             y: Ypos[i],

--- a/res/splitscreen_kwin_horizontal.js
+++ b/res/splitscreen_kwin_horizontal.js
@@ -62,6 +62,8 @@ function gamescopeSplitscreen(){
 
     for (var i = 0; i < gamescopeClients.length; i++){
         gamescopeClients[i].noBorder = true;
+        gamescopeClients[i].keepAbove = true;
+        gamescopeClients[i].skipTaskbar = true;
         gamescopeClients[i].frameGeometry = {
             x: Xpos[i],
             y: Ypos[i],


### PR DESCRIPTION
## Summary
- ensure gamescope windows always stay above the panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855b6a4f32c832aaae915efe35d0325